### PR TITLE
Get entry viewer03

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,14 +72,18 @@ App itself.
 ### Jul. 07 Delivery Day
 
 - branch getEntryViewer
+
   - FR013 Card Layout: Show each entry as a card with preview image, date and title.
+
+- branch getEntryViewer02
+
   - FR014 Entry Detail Modal: Clicking a card opens a modal showing full entry (title, date, image, content). Control showing/hidding the preview modal, as well as its content, with state.
+  - FR015 Static-Site Deployment to Render Build the app with Vite and deploy the static assets on Render.
+
+- branch getEntryViewer03
+  - Delete required confirmation in a warning window.
 
 ## Pending
-
-- FR015 Static-Site Deployment to Render Build the app with Vite and deploy the static assets on Render.
-
-- Delete required confirmation in a warning window.
 
 - Add your first journal welcome page
 - fix responsiveness of the cellphone view? (minimum sizes?)

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ AddEntryModal.jsx
 └── DiaryEntryForm: create a state like showEntryForm. If yes, opens Modal.
 
 App itself.
+├── DiaryEntryIndividual: the preview of the entry.
 └── DiaryEntryList: array of entries filtered by date (stored in localStorage - useState).
-└── DiaryEntryIndividual: is the body of one Entry: date, text, place, mood, usw.
+    └── EntryDetailModal: Modal with the body of one Entry: date, text, place, mood, usw.
 
 ```
 
@@ -72,12 +73,12 @@ App itself.
 
 - branch getEntryViewer
   - FR013 Card Layout: Show each entry as a card with preview image, date and title.
+  - FR014 Entry Detail Modal: Clicking a card opens a modal showing full entry (title, date, image, content). Control showing/hidding the preview modal, as well as its content, with state.
 
 ## Pending
 
-- FR014 Entry Detail Modal Clicking a card opens a modal showing full entry (title, date, image, content). Control showing/hidding the preview modal, as well as its content, with state.
-
 - FR015 Static-Site Deployment to Render Build the app with Vite and deploy the static assets on Render.
+
 - Delete required confirmation in a warning window.
 
 - Add your first journal welcome page

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -46,6 +46,12 @@ const App = () => {
     setSelectedEntry(null);
   };
 
+  // handleDelete function to remove an entry and close the modal
+  const handleDelete = (entryToDelete) => {
+    removeEntry(entryToDelete);
+    closeEntryModal();
+  };
+
   // FOR FILTER: list of entries based on sort order
   const sortedEntries = [...entries].sort((a, b) => {
     // sort entries by date
@@ -80,6 +86,7 @@ const App = () => {
           <EntryDetailModal
             entryData={selectedEntry}
             onClose={closeEntryModal}
+            onDelete={handleDelete}
           />
         )}
       </main>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,16 +6,16 @@
 import { useState, useEffect } from "react";
 import Navbar from "./components/Navbar";
 import DiaryEntryList from "./components/DiaryEntryList";
-import FilterBar from "./components/FilterBar";
 import AddEntryModal from "./components/AddEntryModal";
 import { canSubmitNewEntry, getRemainingCooldown } from "./utils/entryCooldown"; // utility functions for cooldown logic
 import { useDiaryEntries } from "./utils/useDiaryEntries";
+import EntryDetailModal from "./components/EntryDetailModal";
 
 const App = () => {
   const { entries, addEntry, removeEntry } = useDiaryEntries(); // this was in App.jsx before, now in useDiaryEntries.js utility.
   const [isModalOpen, setIsModalOpen] = useState(false); // Modal starts off closed
-
-  const [sortOrder, setSortOrder] = useState("newest"); // default sort order
+  const [sortOrder, setSortOrder] = useState("newest"); // FOR FILTER: default sort order
+  const [selectedEntry, setSelectedEntry] = useState(null); // For entry detail modal.
 
   // handleSubmit function to add a new entry
   // This function will be passed down to the DiaryEntryForm component
@@ -36,6 +36,16 @@ const App = () => {
     }
   };
 
+  // open modal on card click
+  const openEntryModal = (entry) => {
+    setSelectedEntry(entry);
+  };
+
+  // close modal
+  const closeEntryModal = () => {
+    setSelectedEntry(null);
+  };
+
   // FOR FILTER: list of entries based on sort order
   const sortedEntries = [...entries].sort((a, b) => {
     // sort entries by date
@@ -54,11 +64,22 @@ const App = () => {
         setSortOrder={setSortOrder}
       />
       <main className="container mx-auto p-4">
-        <DiaryEntryList entryData={sortedEntries} removeEntry={removeEntry} />
+        <DiaryEntryList
+          entryData={sortedEntries}
+          removeEntry={removeEntry}
+          onEntryClick={openEntryModal}
+        />
         {isModalOpen && (
           <AddEntryModal
             onClose={() => setIsModalOpen(false)}
             handleSubmit={handleSubmit}
+          />
+        )}
+
+        {selectedEntry && (
+          <EntryDetailModal
+            entryData={selectedEntry}
+            onClose={closeEntryModal}
           />
         )}
       </main>

--- a/src/components/DiaryEntryIndividual.jsx
+++ b/src/components/DiaryEntryIndividual.jsx
@@ -32,7 +32,7 @@ const DiaryEntry = ({ entryData, onClick }) => {
   return (
     <div
       className="card card-compact bg-gray-800 shadow-sm mb-4 border border-gray-200 transition duration-200 transform hover:scale-105 hover:shadow-xl cursor-pointer"
-      onClick={onClick}
+      onClick={() => onClick(entryData)}
     >
       {entryData.imageUrl && (
         <figure className="max-h-40 overflow-hidden">

--- a/src/components/DiaryEntryList.jsx
+++ b/src/components/DiaryEntryList.jsx
@@ -1,17 +1,17 @@
 import DiaryEntry from "./DiaryEntryIndividual";
 import React from "react";
 
-const DiaryEntryList = ({ entryData, removeEntry }) => {
+const DiaryEntryList = ({ entryData, removeEntry, onEntryClick }) => {
   return (
     <div className="flex flex-wrap -mx-2">
       {entryData.map((entry, index) => (
         <div key={index} className="w-full sm:w-1/2 md:w-1/3 px-2 mb-4">
           <DiaryEntry
+            key={index}
             entryData={entry}
-            onClick={() => {
-              // TODO: handle open modal
-              console.log("Clicked entry", entry);
-            }}
+            index={index}
+            removeEntry={removeEntry}
+            onClick={onEntryClick}
           />
         </div>
       ))}

--- a/src/components/EntryDetailModal.jsx
+++ b/src/components/EntryDetailModal.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import FullImageModal from "./FullImageModal";
+
+const EntryDetailModal = ({ entryData, onClose }) => {
+  const [isFullImageOpen, setIsFullImageOpen] = useState(false);
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 backdrop-blur-lg bg-gray-900/60 flex items-center justify-center z-40"
+        onClick={onClose}
+      >
+        <div
+          className="card lg:card-side bg-base-100 shadow-lg max-w-4xl w-full relative"
+          onClick={(e) => e.stopPropagation()} // prevent close when clicking inside
+        >
+          {entryData.imageUrl && (
+            <figure
+              className="w-full lg:w-1/2 max-h-96 overflow-hidden cursor-pointer"
+              onClick={() => setIsFullImageOpen(true)}
+            >
+              <img
+                src={entryData.imageUrl}
+                alt="Entry"
+                className="object-cover w-full h-full"
+              />
+            </figure>
+          )}
+
+          <div className="card-body w-full lg:w-1/2 p-6">
+            <h2 className="card-title text-2xl font-bold">{entryData.title}</h2>
+            <small className="text-sm text-gray-500 mb-2">
+              {entryData.date}
+            </small>
+            <p className="whitespace-pre-line mb-4">{entryData.body}</p>
+            <span className="badge badge-outline w-fit">{entryData.mood}</span>
+
+            <div className="card-actions justify-end mt-6">
+              <button className="btn btn-sm btn-error" onClick={onClose}>
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {isFullImageOpen && (
+        <FullImageModal
+          imageUrl={entryData.imageUrl}
+          onClose={() => setIsFullImageOpen(false)}
+        />
+      )}
+    </>
+  );
+};
+
+export default EntryDetailModal;

--- a/src/components/EntryDetailModal.jsx
+++ b/src/components/EntryDetailModal.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import FullImageModal from "./FullImageModal";
 
-const EntryDetailModal = ({ entryData, onClose }) => {
+const EntryDetailModal = ({ entryData, onClose, onDelete }) => {
   const [isFullImageOpen, setIsFullImageOpen] = useState(false);
 
   return (
@@ -36,8 +36,21 @@ const EntryDetailModal = ({ entryData, onClose }) => {
             <span className="badge badge-outline w-fit">{entryData.mood}</span>
 
             <div className="card-actions justify-end mt-6">
-              <button className="btn btn-sm btn-error" onClick={onClose}>
+              <button className="btn btn-error" onClick={onClose}>
                 Close
+              </button>
+              <button
+                className="btn btn-neutral btn-dash"
+                onClick={() => {
+                  const confirmed = window.confirm(
+                    "WARNING! Are you sure you want to delete this entry forever from your memories?"
+                  );
+                  if (confirmed) {
+                    onDelete(entryData); // esta función viene desde App y solo se encarga de ejecutar la lógica (sin lógica visual)
+                  }
+                }}
+              >
+                Delete
               </button>
             </div>
           </div>

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -7,8 +7,8 @@ const FilterBar = ({ sortOrder, setSortOrder }) => {
         value={sortOrder}
         onChange={(e) => setSortOrder(e.target.value)}
       >
-        <option value="oldest">Oldest First</option>
         <option value="newest">Newest First</option>
+        <option value="oldest">Oldest First</option>
       </select>
     </div>
   );

--- a/src/components/FullImageModal.jsx
+++ b/src/components/FullImageModal.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+const FullImageModal = ({ imageUrl, onClose }) => {
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Full-size image viewer"
+    >
+      <img
+        src={imageUrl}
+        alt="Full-size"
+        className="max-w-full max-h-full rounded-lg shadow-lg"
+        onClick={(e) => e.stopPropagation()} // prevent modal close when clicking image
+      />
+      <button
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute top-4 right-4 text-white text-3xl font-bold cursor-pointer"
+      >
+        &times;
+      </button>
+    </div>
+  );
+};
+
+export default FullImageModal;


### PR DESCRIPTION
- branch getEntryViewer
  - FR013 Card Layout: Show each entry as a card with preview image, date and title.

- branch getEntryViewer02
  - FR014 Entry Detail Modal: Clicking a card opens a modal showing full entry (title, date, image, content). Control showing/hidding the preview modal, as well as its content, with state.
  - FR015 Static-Site Deployment to Render Build the app with Vite and deploy the static assets on Render.

- branch getEntryViewer03
  - Delete required confirmation in a warning window.